### PR TITLE
MemDB with Random Replacement

### DIFF
--- a/memdb/rrdb/rrdb.go
+++ b/memdb/rrdb/rrdb.go
@@ -1,0 +1,129 @@
+package rrdb
+
+import (
+	"sync"
+
+	"github.com/renproject/kv/db"
+)
+
+// rrdb is an in-memory implementation of the `db.Iterable`. rrdb uses the
+// Random Replacement policy to remove data when it runs out of storage space.
+type rrdb struct {
+	cap  int
+	mu   *sync.RWMutex
+	data map[string][]byte
+}
+
+// New returns a new rrdb.
+func New(cap int) db.Iterable {
+	return &rrdb{
+		cap:  cap,
+		mu:   new(sync.RWMutex),
+		data: map[string][]byte{},
+	}
+}
+
+// Insert implements the `db.Iterable` interface.
+func (rrdb rrdb) Insert(key string, value []byte) error {
+	if key == "" {
+		return db.ErrEmptyKey
+	}
+
+	rrdb.mu.Lock()
+	defer rrdb.mu.Unlock()
+
+	if len(rrdb.data) >= rrdb.cap {
+		for deleteKey := range rrdb.data {
+			delete(rrdb.data, deleteKey)
+			break
+		}
+	}
+	rrdb.data[key] = value
+	return nil
+}
+
+// Get implements the `db.Iterable` interface.
+func (rrdb rrdb) Get(key string) ([]byte, error) {
+	rrdb.mu.RLock()
+	defer rrdb.mu.RUnlock()
+
+	val, ok := rrdb.data[key]
+	if !ok {
+		return nil, db.ErrNotFound
+	}
+	return val, nil
+}
+
+// Delete implements the `db.Iterable` interface.
+func (rrdb rrdb) Delete(key string) error {
+	rrdb.mu.Lock()
+	defer rrdb.mu.Unlock()
+
+	delete(rrdb.data, key)
+	return nil
+}
+
+// Size implements the `db.Iterable` interface.
+func (rrdb rrdb) Size() (int, error) {
+	rrdb.mu.RLock()
+	defer rrdb.mu.RUnlock()
+
+	return len(rrdb.data), nil
+}
+
+// Iterator implements the `db.Iterable` interface.
+func (rrdb rrdb) Iterator() db.Iterator {
+	rrdb.mu.RLock()
+	defer rrdb.mu.RUnlock()
+
+	return newIterator(rrdb.data)
+}
+
+type iterator struct {
+	index  int
+	keys   []string
+	values [][]byte
+}
+
+func newIterator(data map[string][]byte) db.Iterator {
+	keys := make([]string, 0, len(data))
+	values := make([][]byte, 0, len(data))
+	for key, value := range data {
+		keys = append(keys, key)
+		values = append(values, value)
+	}
+
+	return &iterator{
+		index:  -1,
+		keys:   keys,
+		values: values,
+	}
+}
+
+// Next implements the `db.Iterator` interface.
+func (iter *iterator) Next() bool {
+	iter.index++
+	return iter.index < len(iter.keys)
+}
+
+// Key implements the `db.Iterator` interface.
+func (iter *iterator) Key() (string, error) {
+	if iter.index == -1 {
+		return "", db.ErrIndexOutOfRange
+	}
+	if iter.index >= len(iter.keys) {
+		return "", db.ErrIndexOutOfRange
+	}
+	return iter.keys[iter.index], nil
+}
+
+// Value implements the `db.Iterator` interface.
+func (iter *iterator) Value() ([]byte, error) {
+	if iter.index == -1 {
+		return nil, db.ErrIndexOutOfRange
+	}
+	if iter.index >= len(iter.keys) {
+		return nil, db.ErrIndexOutOfRange
+	}
+	return iter.values[iter.index], nil
+}

--- a/memdb/rrdb/rrdb_suite_test.go
+++ b/memdb/rrdb/rrdb_suite_test.go
@@ -1,0 +1,13 @@
+package rrdb_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestRrdb(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Rrdb Suite")
+}

--- a/memdb/rrdb/rrdb_test.go
+++ b/memdb/rrdb/rrdb_test.go
@@ -1,0 +1,151 @@
+package rrdb
+
+import (
+	"bytes"
+	"fmt"
+	"testing/quick"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/renproject/kv/db"
+)
+
+var _ = Describe("in-memory implementation of the db with random-replacement", func() {
+	Context("when reading and writing", func() {
+		It("should be able read and write value", func() {
+			readAndWrite := func(key string, value []byte) bool {
+				rrDB := New(10)
+				if key == "" {
+					return true
+				}
+
+				// Expect not value exists in the db with the given key.
+				_, err := rrDB.Get(key)
+				Expect(err).Should(Equal(db.ErrNotFound))
+
+				// Should be able to read the value after inserting.
+				Expect(rrDB.Insert(key, value)).NotTo(HaveOccurred())
+				data, err := rrDB.Get(key)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(bytes.Compare(data, value)).Should(BeZero())
+
+				// Expect no value exists after deleting the value.
+				Expect(rrDB.Delete(key)).NotTo(HaveOccurred())
+				_, err = rrDB.Get(key)
+				return err == db.ErrNotFound
+			}
+
+			Expect(quick.Check(readAndWrite, nil)).NotTo(HaveOccurred())
+		})
+
+		It("should be able to iterable through the db using the iterator", func() {
+			iteration := func(values [][]byte) bool {
+				rrDB := New(len(values))
+
+				// Insert all values and make a map for validation.
+				allValues := map[string][]byte{}
+				for i, value := range values {
+					key := fmt.Sprintf("%v", i)
+					Expect(rrDB.Insert(key, value)).NotTo(HaveOccurred())
+					allValues[key] = value
+				}
+
+				// Expect db size to the number of values we insert.
+				size, err := rrDB.Size()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(size).Should(Equal(len(values)))
+
+				// Expect iterator gives us all the key-value pairs we insert.
+				iter := rrDB.Iterator()
+				for iter.Next() {
+					key, err := iter.Key()
+					Expect(err).NotTo(HaveOccurred())
+					value, err := iter.Value()
+					Expect(err).NotTo(HaveOccurred())
+
+					stored, ok := allValues[key]
+					Expect(ok).Should(BeTrue())
+					Expect(bytes.Compare(value, stored)).Should(BeZero())
+					delete(allValues, key)
+				}
+				return len(allValues) == 0
+			}
+
+			Expect(quick.Check(iteration, nil)).NotTo(HaveOccurred())
+		})
+
+		It("should be able to add new elements past the capacity without increasing the size", func() {
+			iteration := func(values [][]byte) bool {
+				cap := len(values) / 2
+				if cap < 1 {
+					cap = 1
+				}
+				rrDB := New(cap)
+
+				// Insert all values.
+				for i, value := range values {
+					key := fmt.Sprintf("%v", i)
+					Expect(rrDB.Insert(key, value)).NotTo(HaveOccurred())
+					val, err := rrDB.Get(key)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(val).To(Equal(value))
+				}
+
+				// Expect db size to be max capacity.
+				size, err := rrDB.Size()
+				Expect(err).NotTo(HaveOccurred())
+				if len(values) > 0 {
+					Expect(size).Should(Equal(cap))
+				}
+				return true
+			}
+
+			Expect(quick.Check(iteration, nil)).NotTo(HaveOccurred())
+		})
+
+		It("should return error when trying to get key/value when the iterator doesn't have next value", func() {
+			iteration := func(key string, value []byte) bool {
+				rrDB := New(10)
+				iter := rrDB.Iterator()
+
+				for iter.Next() {
+				}
+
+				_, err := iter.Key()
+				Expect(err).Should(Equal(db.ErrIndexOutOfRange))
+				_, err = iter.Value()
+				Expect(err).Should(Equal(db.ErrIndexOutOfRange))
+
+				return iter.Next() == false
+			}
+
+			Expect(quick.Check(iteration, nil)).NotTo(HaveOccurred())
+		})
+
+		It("should return error when trying to get key/value without calling Next()", func() {
+			iteration := func(key string, value []byte) bool {
+				rrDB := New(10)
+				iter := rrDB.Iterator()
+
+				_, err := iter.Key()
+				Expect(err).Should(Equal(db.ErrIndexOutOfRange))
+				_, err = iter.Value()
+				Expect(err).Should(Equal(db.ErrIndexOutOfRange))
+
+				return iter.Next() == false
+			}
+
+			Expect(quick.Check(iteration, nil)).NotTo(HaveOccurred())
+		})
+
+		It("should return ErrEmptyKey when trying to insert a value with empty key", func() {
+			iteration := func(value []byte) bool {
+				rrDB := New(10)
+				return rrDB.Insert("", value) == db.ErrEmptyKey
+			}
+
+			Expect(quick.Check(iteration, nil)).NotTo(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
This PR introduces a version of `memdb` with Random Replacement policy. This will ensure that the DB will not exceed a capacity (which is defined by the user of the cache). In the event that the capacity is exceeded, data will be randomly removed from the DB.

#### Motivation
The current `memdb` implementation can throw `out of memory` errors when the map runs out of in-memory storage. This implementation allows the user to specify a maximum number of entries that must be stored without replacement.