### PR TITLE
KV releases the iterator once it has finished iterating in the LevelDB implementation

### DIFF
--- a/leveldb/leveldb.go
+++ b/leveldb/leveldb.go
@@ -72,6 +72,7 @@ func (iter *Iterator) Next() bool {
 	next := iter.iter.Next()
 	if !next {
 		iter.inRange = false
+		iter.iter.Release()
 	}
 	return next
 }


### PR DESCRIPTION
LevelDB iterator needs to be released after iterating. Not releasing can potentially cause memory issues.