### PR TITLE
Hotfix : fix different TTL table using same key-prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage
 
 ### Codec
 
-A `Codec` is encodes `interface{}` values into bytes, decode bytes into the `interface{}` values. Generally, when a specific type is not supported, a `Codec` will panic. Out of the box, KV supports:
+A `Codec` encodes `interface{}` values into bytes, decode bytes into the `interface{}` values. Generally, when a specific type is not supported, a `Codec` will panic. Out of the box, KV supports:
 
 - `JSONCodec` which encodes/decodes using the standard library [JSON](https://golang.org/pkg/encoding/json) marshaler, and
 - `GobCodec` which encodes/decodes using the standard library [Gob]https://golang.org/pkg/encoding/gob marshaler (you must explicitly register types outside of KV).

--- a/badgerdb/badgerdb.go
+++ b/badgerdb/badgerdb.go
@@ -178,6 +178,12 @@ func (iter *iterator) Value(value interface{}) error {
 	return iter.codec.Decode(data, value)
 }
 
+// Close implements the `db.Iterator` interface.
+func (iter *iterator) Close() {
+	iter.iter.Close()
+	iter.tx.Discard()
+}
+
 // convertErr will convert badgerDB-specific error to kv error.
 func convertErr(err error) error {
 	switch err {

--- a/cache/lru/lru_test.go
+++ b/cache/lru/lru_test.go
@@ -78,6 +78,8 @@ var _ = Describe("lru cache table wrapper", func() {
 
 						// Expect iterator gives us all the key-value pairs we insert.
 						iter := table.Iterator()
+						defer iter.Close()
+
 						for iter.Next() {
 							key, err := iter.Key()
 							Expect(err).NotTo(HaveOccurred())

--- a/cache/ttl/ttl_test.go
+++ b/cache/ttl/ttl_test.go
@@ -68,7 +68,6 @@ var _ = Describe("TTL cache", func() {
 			Expect(ok).Should(BeTrue())
 			Expect(reflect.DeepEqual(value, stored)).Should(BeTrue())
 			delete(allValues, key)
-			Expect(table.Delete(key)).Should(Succeed())
 		}
 		return len(allValues) == 0
 	}

--- a/cache/ttl/ttl_test.go
+++ b/cache/ttl/ttl_test.go
@@ -130,7 +130,7 @@ var _ = Describe("TTL cache", func() {
 			})
 
 			Context("when creating multiple ttl table with same underlying db", func() {
-				FIt("should not affect each other", func() {
+				It("should not affect each other", func() {
 					database := initializer(codec)
 					defer database.Close()
 
@@ -152,7 +152,7 @@ var _ = Describe("TTL cache", func() {
 						return true
 					}
 
-					Expect(quick.Check(test, &quick.Config{MaxCount: 1000})).NotTo(HaveOccurred())
+					Expect(quick.Check(test, nil)).NotTo(HaveOccurred())
 				})
 			})
 

--- a/db/db.go
+++ b/db/db.go
@@ -71,4 +71,9 @@ type Iterator interface {
 	// Next() or when no next item in the iter will result in
 	// `ErrIndexOutOfRange`
 	Value(value interface{}) error
+
+	// Close must be called after finishing the iteration to release associated
+	// resources. Close should always success and can be called multiple times
+	// without causing error.
+	Close()
 }

--- a/db/table_test.go
+++ b/db/table_test.go
@@ -112,6 +112,7 @@ var _ = Describe("table", func() {
 
 							// Expect iterator gives us all the key-value pairs we inserted.
 							iter := table.Iterator()
+							defer iter.Close()
 							for iter.Next() {
 								key, err := iter.Key()
 								if err != nil {

--- a/leveldb/leveldb.go
+++ b/leveldb/leveldb.go
@@ -75,11 +75,12 @@ func (ldb *levelDB) Delete(key string) error {
 // Size implements the `db.DB` interface.
 func (ldb *levelDB) Size(prefix string) (int, error) {
 	iter := ldb.db.NewIterator(util.BytesPrefix([]byte(prefix)), nil)
+	defer iter.Release()
+
 	counter := 0
 	for iter.Next() {
 		counter++
 	}
-	iter.Release()
 	return counter, nil
 }
 

--- a/leveldb/leveldb.go
+++ b/leveldb/leveldb.go
@@ -130,6 +130,11 @@ func (iter *iter) Value(value interface{}) error {
 	return iter.codec.Decode(val, value)
 }
 
+// Close implements the `db.Iterator` interface.
+func (iter *iter) Close() {
+	iter.iter.Release()
+}
+
 // convertErr will convert levelDB-specific error to kv error.
 func convertErr(err error) error {
 	switch err {

--- a/memdb/memdb.go
+++ b/memdb/memdb.go
@@ -151,3 +151,6 @@ func (iter *iterator) Value(value interface{}) error {
 	data := iter.values[iter.index]
 	return iter.codec.Decode(data, value)
 }
+
+// Close implements the `db.Iterator` interface.
+func (iter *iterator) Close() {}


### PR DESCRIPTION
- Fix the issue which TTL table uses the same key-prefix(`"ttlDataTable_KEY"`) for different tables. If we create different TTL tables of the same DB, they end up to be the same table which can cause critical issues. A test case has been added to make sure the fix works and this case is being covered in future releases. 
- Add a `Close()` function to the `Iterator` interface which must be called after done with iteration.
It will release all the related resources.


