### PR TITLE
Fix build badger of the repo

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Go
+name: go
 on: [push]
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `📦 kv`
 
 [![GoDoc](https://godoc.org/github.com/renproject/kv?status.svg)](https://godoc.org/github.com/renproject/kv)
-[![CircleCI](https://circleci.com/gh/renproject/kv/tree/master.svg?style=shield)](https://circleci.com/gh/renproject/kv/tree/master)
+![](https://github.com/renproject/kv/workflows/Test/badge.svg)
 ![Go Report](https://goreportcard.com/badge/github.com/renproject/kv)
 [![Coverage Status](https://coveralls.io/repos/github/renproject/kv/badge.svg?branch=master)](https://coveralls.io/github/renproject/kv?branch=master)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ go get github.com/renproject/kv
 Requirements
 ------------
 
-Requires `go1.12` or newer.
+Requires `go1.11` or newer.
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `📦 kv`
 
 [![GoDoc](https://godoc.org/github.com/renproject/kv?status.svg)](https://godoc.org/github.com/renproject/kv)
-![](https://github.com/renproject/kv/workflows/Test/badge.svg)
+![](https://github.com/renproject/kv/workflows/Go/badge.svg)
 ![Go Report](https://goreportcard.com/badge/github.com/renproject/kv)
 [![Coverage Status](https://coveralls.io/repos/github/renproject/kv/badge.svg?branch=master)](https://coveralls.io/github/renproject/kv?branch=master)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `📦 kv`
 
 [![GoDoc](https://godoc.org/github.com/renproject/kv?status.svg)](https://godoc.org/github.com/renproject/kv)
-![](https://github.com/renproject/kv/workflows/Go/badge.svg)
+![](https://github.com/renproject/kv/workflows/go/badge.svg)
 ![Go Report](https://goreportcard.com/badge/github.com/renproject/kv)
 [![Coverage Status](https://coveralls.io/repos/github/renproject/kv/badge.svg?branch=master)](https://coveralls.io/github/renproject/kv?branch=master)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ go get github.com/renproject/kv
 Requirements
 ------------
 
-Requires `go1.6` or newer.
+Requires `go1.12` or newer.
 
 Usage
 -----


### PR DESCRIPTION
- Remove CircleCI status badger and add status badger of Github action.
- Pump the minimum required version of go, as go mod is only supported in 1.11.